### PR TITLE
[JITERA] Add number of staff column to University table and update GraphQL mutations

### DIFF
--- a/src/db/migrations/1733118742233-AddNumberOfStaffToUniversity.ts
+++ b/src/db/migrations/1733118742233-AddNumberOfStaffToUniversity.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
+
+export class AddNumberOfStaffToUniversity1733118742233 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.addColumn('universities', new TableColumn({
+      name: 'number_of_staff',
+      type: 'int',
+      isNullable: true,
+    }));
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropColumn('universities', 'number_of_staff');
+  }
+}

--- a/src/db/models/university.entity.ts
+++ b/src/db/models/university.entity.ts
@@ -16,4 +16,5 @@ export default class University {
 
   @Field() @CreateDateColumn({name: 'created_at'}) createdAt: Date;
   @Field() @UpdateDateColumn({name: 'updated_at'}) updatedAt: Date;
+  @Field({ nullable: true }) @Column({ nullable: true }) number_of_staff?: number;
 }

--- a/src/resolvers/input/university.input.ts
+++ b/src/resolvers/input/university.input.ts
@@ -11,6 +11,7 @@ class UniversityInput {
   @Field() readonly city: string;
   @Field() readonly state: string;
   @Field() readonly country: string;
+  @Field({ nullable: true }) readonly number_of_staff?: number;
 }
 
 export default UniversityInput;


### PR DESCRIPTION
Overview:
This pull request adds a new column `number_of_staff` to the `University` table and updates the GraphQL mutations to handle this new field.

Changes:
1. Created a new migration file to add the `number_of_staff` column to the `University` table.
2. Updated the `University` entity to include the new field.
3. Modified the input types for the create and update university mutations to include the `number_of_staff` field.

Explanation:
1. The new migration file will ensure that the `number_of_staff` column is added to the database.
2. The `University` entity is updated to include the new field, allowing for the data to be accessed and manipulated.
3. The input types for the create and update university mutations are modified to include the `number_of_staff` field, ensuring that the GraphQL mutations can handle this new data.
